### PR TITLE
feat: add KubeStellar Console kc-agent to Cloud & Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ MCP is an open protocol that lets AI assistants (Claude, GPT, Cursor, Windsurf, 
 | [DigitalOcean MCP](https://github.com/digitalocean-labs/mcp-digitalocean) | Official DO droplets, apps, databases | Go |
 | [Heroku MCP](https://github.com/heroku/heroku-mcp-server) | Official Heroku platform CLI wrapper | TypeScript |
 | [Helm MCP](https://github.com/zekker6/mcp-helm) | Helm package manager for Kubernetes | Go |
+| [KubeStellar Console kc-agent](https://github.com/kubestellar/console) | MCP server for multi-cluster Kubernetes AI operations (CNCF Sandbox) | Go |
 | [Nomad MCP](https://github.com/kocierik/mcp-nomad) | HashiCorp Nomad cluster operations | Go |
 
 ### Productivity


### PR DESCRIPTION
Adds **[KubeStellar Console kc-agent](https://github.com/kubestellar/console)** to the **Cloud & Infrastructure** section.

kc-agent is the MCP server for KubeStellar Console, a CNCF Sandbox multi-cluster Kubernetes platform. It enables AI tools to manage workloads, query health, and orchestrate across edge and cloud Kubernetes clusters.

- GitHub: https://github.com/kubestellar/console
- Demo: https://console.kubestellar.io