### PR TITLE
Add NotFair (Google Ads MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ MCP is an open protocol that lets AI assistants (Claude, GPT, Cursor, Windsurf, 
 | [HubSpot MCP](https://github.com/baryhuang/mcp-hubspot) | HubSpot CRM with vector storage | Python |
 | [PostHog MCP](https://github.com/PostHog/mcp) | Official PostHog product analytics | TypeScript |
 | [Mixpanel MCP](https://github.com/dragonkhoi/mixpanel-mcp) | Talk to your Mixpanel data | TypeScript |
+| [NotFair Google Ads MCP](https://github.com/nowork-studio/toprank) | Connect Claude and AI agents to Google Ads: diagnose performance, recommend optimizations, execute approved changes via the Google Ads API with a built-in human-approval gate. Hosted, streamable-HTTP. | Hosted (Python) |
 
 ### Knowledge Management
 


### PR DESCRIPTION
Adding NotFair under Marketing & Analytics. It's a Google Ads MCP server that lets Claude and other AI agents diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API.

Source: github.com/nowork-studio/toprank
Registry: io.github.nowork-studio/notfair (active in the official MCP registry)
Endpoint: streamable-http at notfair.co/api/mcp/google_ads

Free tier available. Happy to adjust the format if you'd prefer.