### PR TITLE
Add TWZRD Agent Intel to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ MCP is an open protocol that lets AI assistants (Claude, GPT, Cursor, Windsurf, 
 | [QuickBooks MCP](https://github.com/intuit/quickbooks-online-mcp-server) | Official Intuit QuickBooks Online | TypeScript |
 | [Square MCP](https://github.com/square/square-mcp-server) | Official Square payments and commerce | TypeScript |
 | [Ramp MCP](https://github.com/ramp-public/ramp_mcp) | Official Ramp corporate cards + expenses | Python |
+| [TWZRD Agent Intel](https://intel.twzrd.xyz) | Solana on-chain trust scoring for AI agents. Verify wallet reputation before x402 micropayments | Remote |
 
 ### Monitoring & Observability
 


### PR DESCRIPTION
TWZRD Agent Intel provides on-chain trust scoring for AI agents operating on Solana. It belongs in the Finance section alongside Coinbase, Stripe, and Alpaca as infrastructure for agent-to-agent economic trust.

**Server details:**
- Live at: https://intel.twzrd.xyz
- MCP endpoint: https://intel.twzrd.xyz/mcp (streamable-http, no API key required)
- Tools: `score_agent(wallet)`, `preflight_check(wallet)` (free), `get_trust_receipt(wallet)` (paid x402)

Quick setup: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`