### PR TITLE
Add ax MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ MCP is an open protocol that lets AI assistants (Claude, GPT, Cursor, Windsurf, 
 
 | Server | Description | Language |
 |--------|-------------|----------|
+| [ax](https://github.com/Necmttn/ax) | Agent session telemetry and cost analytics | TypeScript |
 | [Datadog MCP](https://github.com/winor30/mcp-server-datadog) | Datadog metrics, logs, monitors | TypeScript |
 | [Grafana MCP](https://github.com/grafana/mcp-grafana) | Official Grafana dashboards and alerts | Go |
 | [Loki MCP](https://github.com/grafana/loki-mcp) | Official Grafana Loki log aggregation | Go |


### PR DESCRIPTION
Adds ax to Monitoring & Observability.

ax fits this section because it exposes read-only MCP queries over local AI coding-agent telemetry, including sessions, tool calls, skill usage, costs, and OTLP events.

---

_Generated with [ax](https://github.com/Necmttn/ax)._