### PR TITLE
Point LLM Pulse entry to official repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ MCP is an open protocol that lets AI assistants (Claude, GPT, Cursor, Windsurf, 
 | [PostHog MCP](https://github.com/PostHog/posthog/tree/master/services/mcp) | Official PostHog product analytics | TypeScript |
 | [Mixpanel MCP](https://github.com/dragonkhoi/mixpanel-mcp) | Talk to your Mixpanel data | TypeScript |
 | [NotFair](https://github.com/nowork-studio/NotFair) | Google Ads, Meta Ads, and SEO skills with human-approval gate | TypeScript |
-| [LLM Pulse MCP](https://github.com/estevecastells/llmpulse-mcp) | AI search visibility (GEO/AEO): mentions, citations, share of voice, AI traffic across ChatGPT, Perplexity, Gemini, Google AI Overviews | Ruby |
+| [LLM Pulse MCP](https://github.com/LLM-Pulse/llmpulse-mcp) | AI visibility analytics for mentions, citations, sentiment, and AI traffic | JavaScript |
 
 ### Knowledge Management
 


### PR DESCRIPTION
Updates the existing LLM Pulse MCP entry to the official repository and current concise description.\n\nChanges:\n- Switches the URL from `estevecastells/llmpulse-mcp` to `LLM-Pulse/llmpulse-mcp`\n- Tightens the description to match the contribution guide length/style\n- Sets the language to JavaScript for the public MCP wrapper repo