### PR TITLE
Add AISOTools MCP to AI & ML

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ MCP is an open protocol that lets AI assistants (Claude, GPT, Cursor, Windsurf, 
 | [RouterBase MCP](https://github.com/zenlee123/routerbase-mcp) | Model discovery, pricing lookup, and OpenAI-compatible chat completions through [routerbase](https://routerbase.com) | TypeScript |
 | [Weights & Biases MCP](https://github.com/wandb/wandb-mcp-server) | Official W&B Models + Weave | Python |
 | [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) | Image generation across 30+ models via unified API | JavaScript |
+| [AISOTools MCP](https://aisotools.com/mcp) | AI-tool catalog search, comparison, and alternatives lookup | Remote |
 
 ### Finance
 


### PR DESCRIPTION
One row in **AI & ML**, following the `| [Name](URL) | Description | Language |` format and the `Remote` convention already used by Replicate, Logfire and Honeycomb.

A hosted MCP server over a catalog of AI tools — the "which tool does X" question, answerable by an agent instead of by a directory search box. Five tools:

- `search_ai_tools` — keyword + category + pricing-model search, ranked
- `compare_ai_tools` / `find_ai_tool_alternatives` — side-by-side and swap-out lookups
- `get_ai_tool` / `list_ai_tool_categories`

Endpoint is `https://aisotools.com/api/mcp`, streamable HTTP, **no auth and no signup** — `tools/list` answers over plain curl, so it is testable before you merge. Docs: [aisotools.com/mcp](https://aisotools.com/mcp).

Your guidelines prefer official/vendor-maintained servers over community forks: this is the vendor-maintained server for its own catalog. **Disclosure: I run AISOTools.** Happy to move it to another category or close this if it is not a fit.