### PR TITLE
Add Autoposting to Marketing &amp; Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ MCP is an open protocol that lets AI assistants (Claude, GPT, Cursor, Windsurf, 
 | [Mixpanel MCP](https://github.com/dragonkhoi/mixpanel-mcp) | Talk to your Mixpanel data | TypeScript |
 | [NotFair](https://github.com/nowork-studio/NotFair) | Google Ads, Meta Ads, and SEO skills with human-approval gate | TypeScript |
 | [LLM Pulse MCP](https://github.com/LLM-Pulse/llmpulse-mcp) | AI visibility analytics for mentions, citations, sentiment, and AI traffic | JavaScript |
+| [Autoposting](https://github.com/Autoposting-ai/autoposting-mcp) | Schedule, generate and publish social posts to X, LinkedIn, Instagram, Threads and YouTube | TypeScript |
 
 ### Knowledge Management
 


### PR DESCRIPTION
Adds Autoposting to the Marketing & Analytics table.

Remote MCP server (Streamable HTTP + OAuth 2.1 DCR) at `https://app.autoposting.ai/mcp`, public repo [Autoposting-ai/autoposting-mcp](https://github.com/Autoposting-ai/autoposting-mcp). Tools cover post creation, scheduling, publishing, carousels, video clipping, and knowledge bases across X, LinkedIn, Instagram, Threads and YouTube.

One table row added, columns match the existing format.