### PR TITLE
Add sms-florin MCP to Communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ MCP is an open protocol that lets AI assistants (Claude, GPT, Cursor, Windsurf, 
 | [Microsoft Teams MCP](https://github.com/InditexTech/mcp-teams-server) | Teams channels, messages, meetings | Python |
 | [Matrix MCP](https://github.com/mjknowles/matrix-mcp-server) | Matrix chat protocol server | TypeScript |
 | [Resend MCP](https://github.com/resend/resend-mcp) | Official Resend transactional email | TypeScript |
+| [sms-florin MCP](https://github.com/flovoice53-tech/sms-florin-mcp) | Rent real UK SMS numbers to test OTP/verification flows | TypeScript |
 
 ### File Systems & Storage
 


### PR DESCRIPTION
## Add MCP Server

- **Server name**: sms-florin MCP
- **URL**: https://github.com/flovoice53-tech/sms-florin-mcp
- **Category**: Communication
- **Language**: TypeScript

MCP server that lets AI coding agents rent a real UK phone number (physical SIM cards on EE/Three networks, not VoIP) and fetch the incoming SMS/OTP code — useful when an agent is testing a signup/verification flow mid-task and needs a real code instead of a mocked one.

### Checklist

- [x] Server implements MCP (Model Context Protocol)
- [x] Repository is public and open source (MIT license)
- [x] README has setup/usage instructions
- [x] Not a duplicate of an existing entry
- [x] Added in alphabetical order within category (appended at end, matching existing non-strict ordering in the section)
- [x] Description is concise (under 80 characters)
- [x] Link works and points to the correct repository